### PR TITLE
fix(Makefile): Use go env instead of GOPATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
+GOPATH ?= $(shell go env GOPATH)
+
 .PHONY: schemas
 schemas:
-	@ln -sfn $$GOPATH/pkg/mod/github.com/prometheus/prometheus@v0.52.0 go/prometheus && \
-		ln -sfn $$GOPATH/pkg/mod/github.com/prometheus/common@v0.53.0 go/common && \
+	@ln -sfn $(GOPATH)/pkg/mod/github.com/prometheus/prometheus@v0.52.0 go/prometheus && \
+		ln -sfn $(GOPATH)/pkg/mod/github.com/prometheus/common@v0.53.0 go/common && \
 		cd go && go run . && \
 		mv config.json ../generator/config.json && \
 		mv rulegroups.json ../generator/rulegroups.json


### PR DESCRIPTION
Updates the Makefile to conditionally set GOPATH to the result of `go env GOPATH` if GOPATH is not already set. This should preserve functionality for existing users, while allowing those without GOPATH set to run `make schemas`

- resolves #2